### PR TITLE
Sort by reverse date, fix issue 4

### DIFF
--- a/_pages/administrative.adoc
+++ b/_pages/administrative.adoc
@@ -4,8 +4,9 @@ title: Administrative documents
 parent: "/"
 ---
 :page-liquid:
+{% assign sorted = site.data.admin.root.items | sort: 'revdate' | reverse %}
 ++++
-{% for document in site.data.admin.root.items %}
+{% for document in sorted %}
 {% assign depth = "3" %}
 {% include document.html %}
 {% endfor %}

--- a/_pages/standards.adoc
+++ b/_pages/standards.adoc
@@ -4,8 +4,9 @@ title: Standards
 parent: "/"
 ---
 :page-liquid:
+{% assign sorted = site.data.standards.root.items | sort: 'revdate' | reverse %}
 ++++
-{% for document in site.data.standards.root.items %}
+{% for document in sorted %}
 {% assign depth = "3" %}
 {% include document.html %}
 {% endfor %}


### PR DESCRIPTION
As title.

However there are two problems to be resolved.

1. The generated documents don't have a `revdate` "date" because they are "published by year". The current grammar calls the published year `edition-year` (there's only year), while `revdate` is day-month-year. How do we sort these?

2. Newly proposed items don't have a date -- because they're not published. Should we fill in the current year for all of these?
