### PR TITLE
date format adjustment

### DIFF
--- a/_pages/public-review.adoc
+++ b/_pages/public-review.adoc
@@ -6,7 +6,7 @@ parent: "/"
 :page-liquid:
 {% assign depth = "4" %}
 
-== Public review ends 2018/12/01
+== Public review ends 2018-12-01
 
 ++++
 {% assign identifier = "CC/FDS 18011:2018" %}
@@ -18,14 +18,14 @@ parent: "/"
 {% include find-doc.html %}
 ++++
 
-== Public review ends 2018/12/23
+== Public review ends 2018-12-23
 
 ++++
 {% assign identifier = "CC/R/DS 18003:2018" %}
 {% include find-doc.html %}
 ++++
 
-== Internal review ends 2018/12/01
+== Internal review ends 2018-12-01
 
 ++++
 {% assign identifier = "CC/DIR/FDS 10001:2018" %}


### PR DESCRIPTION
Question of which date format to use.

e.g. https://www.calendarstandards.org/public-review/ includes 2018/12/01

documents itself as https://www.calendarstandards.org/standards/csd-datetime-explicit.html include 2018-09-25

datatracker also uses 2018-11-05  e.g. https://datatracker.ietf.org/doc/draft-ietf-calext-jscalendar/

Suggestion: user YYYY-MM-DD everywhere.