### PR TITLE
Fix site generation related issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "metanorma-cli"
 
 # gem "metanorma-cli", path: "~/src/metanorma-cli"
 # gem "relaton-cli"
-gem "relaton-cli", git: "https://github.com/riboseinc/relaton-cli"
+gem "relaton-cli", git: "https://github.com/metanorma/relaton-cli"
 # gem "relaton-cli", path: "~/src/relaton-cli"
 
 # __________________ JEKYLL BELOW __________________

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/riboseinc/relaton-cli
-  revision: 65f3cd64c599715eda1e0922b9a548809a9059a9
+  remote: https://github.com/metanorma/relaton-cli
+  revision: a3d894fc21c626c89e8d431f1e607351aaae8a3e
   specs:
     relaton-cli (0.1.9)
       liquid
@@ -21,7 +21,7 @@ GEM
     cldr-plurals-runtime-rb (1.0.1)
     cnccs (0.1.3)
     colorator (1.1.0)
-    concurrent-ruby (1.1.4)
+    concurrent-ruby (1.1.5)
     em-websocket (0.5.1)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
@@ -294,4 +294,4 @@ DEPENDENCIES
   tzinfo-data
 
 BUNDLED WITH
-   1.17.3
+   2.0.1

--- a/Makefile
+++ b/Makefile
@@ -85,14 +85,6 @@ _input/%.rxl: _input/%.yaml
 _input/csd.yaml: _input/csd.rxl
 	bundle exec relaton xml2yaml $<
 
-# Steps:
-# 1. Split the `_input/%.yaml` into `bib/*.rxl` files.
-# 2. Run `relaton concatenate` to combine the bib/*.rxl files, allowing
-#    detection of the RXL link, into `bibcoll/%.xml`.
-# 3. Run `relaton xml2yaml` to split the concatenated collection `bibcoll/%.rxl`
-#    into `bib/*.yaml` files with RXL links.
-# 4. Run `relaton yaml2xml` to split the concatenated `bibcoll/%.yaml`
-#    back into `bib/*.rxl` files.
 $(BIBCOLL_OUTPUT_DIR)/%.rxl: _input/%.rxl $(BIB_OUTPUT_DIR) $(BIBCOLL_OUTPUT_DIR)
 	bundle exec relaton split \
 		$< \
@@ -101,18 +93,7 @@ $(BIBCOLL_OUTPUT_DIR)/%.rxl: _input/%.rxl $(BIB_OUTPUT_DIR) $(BIBCOLL_OUTPUT_DIR
 	bundle exec relaton split \
 		$< \
 		$(BIB_OUTPUT_DIR) \
-		-x yaml; \
-	# bundle exec relaton concatenate \
-	#   -t $(CSD_REGISTRY_NAME) \
-	# 	-g $(NAME_ORG) \
-	#   $(BIB_OUTPUT_DIR) $@; \
-	# bundle exec relaton xml2yaml \
-	# 	-o $(BIB_OUTPUT_DIR) \
-	# 	$@;
-	# bundle exec relaton yaml2xml \
-	# 	-x rxl \
-	# 	-o $(BIB_OUTPUT_DIR) \
-	# 	$(patsubst %.rxl,%.yaml,$@)
+		-x yaml;
 
 $(CSD_OUTPUT_DIR):
 	mkdir -p $@

--- a/_includes/document.html
+++ b/_includes/document.html
@@ -37,13 +37,12 @@
 {%- endif -%}
 {%- endunless -%}
 
-{%- unless document.rxl == blank or document.rxl == nil -%}
-{%- if document.rxl contains '://' -%}
+{%- assign rxluri = nil -%}
+{%- if document.rxl and document.rxl contains "://" -%}
 {%- assign rxluri = document.rxl -%}
 {%- else -%}
-{%- assign rxluri = document.rxl | prepend: "/" -%}
+{%- assign rxluri = document.bib_rxl || document.rxl | prepend: "/" -%}
 {%- endif -%}
-{%- endunless -%}
 
   <div class="doc-line">
     <div class="doc-identifier">
@@ -92,13 +91,13 @@
   </div>
   {%- endunless -%}
 
-  {%- unless document.rxl == blank or document.rxl == nil -%}
+  {%- if rxluri -%}
   <div class="doc-bib">
     <div class="doc-bib-rxl">
       <a href="{{ rxluri }}">Relaton XML</a>
     </div>
   </div>
-  {%- endunless -%}
+  {%- endif -%}
 
   <div class="doc-access">
    {%- unless htmluri == blank or htmluri == nil -%}


### PR DESCRIPTION
Previously, we were splitting and concatenating files a couple of times to build the relaton XML links, and recently we have added a dedicated split interface to optimize it, and which does all of the work. But it did introduce some issues, it wasn't generating the site properly.

This commit fixes these issues, so we can use this new interface and also keep all existing functionality intact.

@ronaldtse: Could you please verify and merge it if that satisfy our requirements?