### PR TITLE
Fix relaton link generation issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,10 @@
 source "https://rubygems.org"
 
 gem "metanorma-cli"
-# gem "metanorma-csd", path: "~/src/relaton-cli"
-
 # gem "metanorma-cli", path: "~/src/metanorma-cli"
-gem "relaton-cli"
-# gem "relaton-cli", git: "https://github.com/metanorma/relaton-cli"
+#
+gem "relaton-cli", "~> 0.1.10"
+# gem "relaton-cli", git: "https://github.com/metanorma/relaton-cli", tag: "v0.1.10"
 # gem "relaton-cli", path: "~/src/relaton-cli"
 
 # __________________ JEKYLL BELOW __________________

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,13 +24,13 @@ GEM
       cnccs (~> 0.1.1)
       gb-agencies (~> 0.0.1)
       iso-bib-item (~> 0.4.2)
-    html2doc (0.8.9)
+    git (1.5.0)
+    html2doc (0.8.10)
       asciimath (~> 1.0.7)
       htmlentities (~> 4.3.4)
       image_size
       mime-types
       nokogiri
-      ruby-xslt
       thread_safe
       uuidtools
     htmlentities (4.3.4)
@@ -41,13 +41,13 @@ GEM
     iecbib (0.2.2)
       addressable
       iso-bib-item (~> 0.4.2)
-    ietfbib (0.4.5)
+    ietfbib (0.4.6)
       iso-bib-item (~> 0.4.2)
     iev (0.2.2)
       nokogiri
     image_size (2.0.0)
     iso-639 (0.2.8)
-    iso-bib-item (0.4.4)
+    iso-bib-item (0.4.5)
       isoics (~> 0.1.6)
       nokogiri (~> 1.8.4)
       ruby_deep_clone (~> 0.8.0)
@@ -55,7 +55,7 @@ GEM
       algoliasearch
       iecbib (~> 0.2.1)
       iso-bib-item (~> 0.4.2)
-    isodoc (0.9.20)
+    isodoc (0.9.22)
       asciimath
       html2doc (~> 0.8.6)
       htmlentities (~> 4.3.4)
@@ -109,7 +109,8 @@ GEM
       isodoc (~> 0.9.0)
       metanorma-standoc (~> 1.1.0)
       ruby-jing
-    metanorma-cli (1.1.6)
+    metanorma-cli (1.1.7)
+      git (~> 1.5)
       isodoc (~> 0.9.0)
       metanorma (~> 0.3.9)
       metanorma-acme (~> 1.1.0)
@@ -126,7 +127,8 @@ GEM
       metanorma-standoc (~> 1.1.0)
       metanorma-unece (~> 0.0.1)
       nokogiri (>= 1)
-    metanorma-csand (1.1.4)
+      thor (~> 0.20.3)
+    metanorma-csand (1.1.5)
       asciidoctor (~> 1.5.7)
       asciimath
       htmlentities (~> 4.3.4)
@@ -136,7 +138,6 @@ GEM
       mime-types
       nokogiri
       ruby-jing
-      ruby-xslt
       thread_safe
       uuidtools
     metanorma-csd (1.1.4)
@@ -157,7 +158,7 @@ GEM
       isodoc (~> 0.9.8)
       metanorma-standoc (~> 1.1.0)
       ruby-jing
-    metanorma-m3d (1.1.4)
+    metanorma-m3d (1.1.5)
       asciidoctor (~> 1.5.7)
       asciimath
       htmlentities (~> 4.3.4)
@@ -167,7 +168,6 @@ GEM
       mime-types
       nokogiri
       ruby-jing
-      ruby-xslt
       thread_safe
       uuidtools
     metanorma-mpfd (0.1.10)
@@ -177,14 +177,14 @@ GEM
       metanorma-standoc (~> 1.1.0)
       nokogiri
       twitter_cldr
-    metanorma-nist (0.0.6)
+    metanorma-nist (0.0.8)
       asciidoctor (~> 1.5.7)
       htmlentities (~> 4.3.4)
       isodoc (~> 0.9.0)
       metanorma-standoc (~> 1.1.0)
       ruby-jing
       twitter_cldr
-    metanorma-ogc (0.0.8)
+    metanorma-ogc (0.0.9)
       asciidoctor (~> 1.5.7)
       htmlentities (~> 4.3.4)
       iso-639
@@ -197,7 +197,7 @@ GEM
       isodoc (~> 0.9.0)
       metanorma-standoc (~> 1.1.0)
       nokogiri
-    metanorma-standoc (1.1.6)
+    metanorma-standoc (1.1.8)
       asciidoctor (~> 1.5.7)
       concurrent-ruby
       html2doc (~> 0.8.0)
@@ -224,6 +224,8 @@ GEM
       jekyll (~> 3.5)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
+    nistbib (0.1.2)
+      iso-bib-item (~> 0.4.2)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     optout (0.0.2)
@@ -234,14 +236,15 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    relaton (0.3.3)
+    relaton (0.3.4)
       algoliasearch
       gbbib (~> 0.4.0)
       iecbib (~> 0.2.0)
       ietfbib (~> 0.4.2)
       iso-bib-item (~> 0.4.2)
       isobib (~> 0.4.0)
-    relaton-cli (0.1.9)
+      nistbib (~> 0.1.1)
+    relaton-cli (0.1.10)
       liquid
       relaton (~> 0.3)
       thor
@@ -249,7 +252,6 @@ GEM
     rouge (3.3.0)
     ruby-jing (0.0.1)
       optout (>= 0.0.2)
-    ruby-xslt (0.9.10)
     ruby_deep_clone (0.8.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)
@@ -283,7 +285,7 @@ DEPENDENCIES
   jekyll-feed (~> 0.6)
   metanorma-cli
   minima (~> 2.0)
-  relaton-cli
+  relaton-cli (~> 0.1.10)
   tzinfo-data
 
 BUNDLED WITH


### PR DESCRIPTION
We've added some new changes to resolve the relaton xml link in relaton-cli `v0.1.10`, but that was never pushed to rubygems.

So, when this application was switched to use the official gem then it was using the old version, and that was causing the issue with the relaton xml link.

This commit changes it to use the github's tagged version, so it will work as expected. As soon as we push the recent relation gem to rubygems then we can start using the official version again.

Fixes #27