### PR TITLE
chore(template): Adjust template paths to be relative to site manifest directory

### DIFF
--- a/src-documents/metanorma-administrative.yml
+++ b/src-documents/metanorma-administrative.yml
@@ -129,4 +129,4 @@ metanorma:
     organization: CalConnect
     name: Administrative Documents
   template:
-    path: ../../src-documents/_relaton_templates
+    path: _relaton_templates

--- a/src-documents/metanorma-advisory.yml
+++ b/src-documents/metanorma-advisory.yml
@@ -12,4 +12,4 @@ metanorma:
     organization: CalConnect
     name: Advisories
   template:
-    path: ../../src-documents/_relaton_templates
+    path: _relaton_templates

--- a/src-documents/metanorma-amendment.yml
+++ b/src-documents/metanorma-amendment.yml
@@ -6,4 +6,4 @@ metanorma:
     organization: CalConnect
     name: Amendments
   template:
-    path: ../../src-documents/_relaton_templates
+    path: _relaton_templates

--- a/src-documents/metanorma-directive.yml
+++ b/src-documents/metanorma-directive.yml
@@ -10,4 +10,4 @@ metanorma:
     organization: CalConnect
     name: Directives
   template:
-    path: ../../src-documents/_relaton_templates
+    path: _relaton_templates

--- a/src-documents/metanorma-guide.yml
+++ b/src-documents/metanorma-guide.yml
@@ -6,4 +6,4 @@ metanorma:
     organization: CalConnect
     name: Guides
   template:
-    path: ../../src-documents/_relaton_templates
+    path: _relaton_templates

--- a/src-documents/metanorma-pending-publication.yml
+++ b/src-documents/metanorma-pending-publication.yml
@@ -7,4 +7,4 @@ metanorma:
     organization: CalConnect
     name: Pending Publication
   template:
-    path: ../../src-documents/_relaton_templates
+    path: _relaton_templates

--- a/src-documents/metanorma-public-review.yml
+++ b/src-documents/metanorma-public-review.yml
@@ -6,4 +6,4 @@ metanorma:
     organization: CalConnect
     name: Documents under Internal Review
   template:
-    path: ../../src-documents/_relaton_templates
+    path: _relaton_templates

--- a/src-documents/metanorma-report.yml
+++ b/src-documents/metanorma-report.yml
@@ -18,4 +18,4 @@ metanorma:
     organization: CalConnect
     name: Reports
   template:
-    path: ../../src-documents/_relaton_templates
+    path: _relaton_templates

--- a/src-documents/metanorma-specification.yml
+++ b/src-documents/metanorma-specification.yml
@@ -17,4 +17,4 @@ metanorma:
     organization: CalConnect
     name: Specifications
   template:
-    path: ../../src-documents/_relaton_templates
+    path: _relaton_templates

--- a/src-documents/metanorma-standard.yml
+++ b/src-documents/metanorma-standard.yml
@@ -19,4 +19,4 @@ metanorma:
     organization: CalConnect
     name: Standards
   template:
-    path: ../../src-documents/_relaton_templates
+    path: _relaton_templates

--- a/src-documents/metanorma-technical-corrigendum.yml
+++ b/src-documents/metanorma-technical-corrigendum.yml
@@ -6,4 +6,4 @@ metanorma:
     organization: CalConnect
     name: Technical Corrigenda
   template:
-    path: ../../src-documents/_relaton_templates
+    path: _relaton_templates


### PR DESCRIPTION
Fixes #69

related: https://github.com/metanorma/metanorma-cli/pull/375

NOTE: If the GHA jobs are failing due to:

```
/usr/local/bundle/gems/relaton-cli-1.20.0/lib/relaton/cli/xml_to_html_renderer.rb:42:in `read':
No such file or directory @ rb_sysopen - _relaton_templates/_index.liquid (Errno::ENOENT)
```

... then that means a new metanorma-cli release has not been published yet.

In that case, wait until a new release is done, then re-run the jobs, and merge as soon as they pass.