### PR TITLE
fix: add display_categories to aggregate config, bump metanorma-release to v0.2.22

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.4"
 gem "jekyll-calconnect-theme"
-gem "metanorma-release", github: "metanorma/metanorma-release", tag: "v0.2.21"
+gem "metanorma-release", github: "metanorma/metanorma-release", tag: "v0.2.22"
 gem "octokit", "~> 9.0"
 gem "relaton-calconnect", "~> 2.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/metanorma/metanorma-release.git
-  revision: 6f70185ce4c46050100a6d4e7465c2110d337883
-  tag: v0.2.21
+  revision: 2cad6141751b1c6e135b939a574a740aa06b5391
+  tag: v0.2.22
   specs:
-    metanorma-release (0.2.21)
+    metanorma-release (0.2.22)
       relaton-bib (~> 2.1)
       thor (~> 1.0)
 
@@ -127,7 +127,7 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
-    lutaml-model (0.8.10)
+    lutaml-model (0.8.11)
       base64
       bigdecimal
       canon
@@ -204,7 +204,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    relaton-bib (2.1.2)
+    relaton-bib (2.1.3)
       bibtex-ruby
       iso639
       isoics (~> 0.1.0)
@@ -355,10 +355,10 @@ CHECKSUMS
   liquid (4.0.4) sha256=4fcfebb1a045e47918388dbb7a0925e7c3893e58d2bd6c3b3c73ec17a2d8fdb3
   listen (3.10.0) sha256=c6e182db62143aeccc2e1960033bebe7445309c7272061979bb098d03760c9d2
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
-  lutaml-model (0.8.10) sha256=3c6308c163f18e7ecf1c79b6ac82d2806559b4e928c440720f41ff0ae5692fe2
+  lutaml-model (0.8.11) sha256=deaa87d51e1d11ba85de4aaeded9fdd2a948c0d92fb379d0ca28898dca75ed03
   mechanize (2.14.0) sha256=33e76b7639d0181a46eaf1136b05f0e9043dfc5fc4b1a7b9fd8ae8bd437dd5e4
   mercenary (0.4.0) sha256=b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138
-  metanorma-release (0.2.21)
+  metanorma-release (0.2.22)
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
   mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   moxml (0.1.20) sha256=917811354a0752371089690c019fb3b0c9599085d6544a0752c85fa22ddd7dc6
@@ -390,7 +390,7 @@ CHECKSUMS
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe
   rb-inotify (0.11.1) sha256=a0a700441239b0ff18eb65e3866236cd78613d6b9f78fea1f9ac47a85e47be6e
-  relaton-bib (2.1.2) sha256=d5d5e1164fb344dd7a5210f6a6011631ecf3c41e6c0aa935bc6b185f05229aca
+  relaton-bib (2.1.3) sha256=bfc645c4cf97736f03d83c5217066842bba0b892a7921556fa87b75433d1389b
   relaton-calconnect (2.1.2) sha256=f9f2b960cbb5471df19dfde38f2ed7c2d8357fe641c9041524e3ab7d860e7e0b
   relaton-core (0.0.13) sha256=10eef0d4bdff18a9058114ca46323508972b8caed872212992c4f9ced7375881
   relaton-index (0.2.21) sha256=de5d15c461551adac8e49ec4c8cc9fcdf238c5295411750dd6e413a7a129653b

--- a/metanorma.aggregate.yml
+++ b/metanorma.aggregate.yml
@@ -1,5 +1,3 @@
-org: CalConnect/.metanorma
-
 source: github
 output_dir: _site/cc
 file_routing: flat
@@ -10,6 +8,32 @@ channels:
   - public
 
 include_drafts: true
+
+display_categories:
+  - name: Standards, Specifications & Reports
+    slug: standards
+    doctypes:
+      - standard
+      - specification
+      - report
+  - name: Guides & Advisories
+    slug: guides
+    doctypes:
+      - guide
+      - advisory
+  - name: Directives
+    slug: directives
+    doctypes:
+      - directive
+  - name: Administrative
+    slug: administrative
+    doctypes:
+      - administrative
+  - name: Amendments & Technical Corrigenda
+    slug: amendments
+    doctypes:
+      - amendment
+      - technical-corrigendum
 
 github:
   organizations:


### PR DESCRIPTION
## Problem
The CalConnect/.metanorma org config repo was archived as part of the two-file architecture migration. The live site shows document counts on the index page but category pages (/standards/, /guides/, etc.) show "No documents" because `display_category_slug` is empty on all documents.

## Fix
- Add `display_categories` to `metanorma.aggregate.yml` (was previously read from the archived org config repo)
- Bump metanorma-release gem to v0.2.22 which reads `display_categories` from the aggregate config instead of `OrgConfig`

## Verification
Local aggregation produces 168 documents with correct category assignments:
- standards: 44
- guides: 4
- directives: 2
- administrative: 117