### PR TITLE
fix: bump metanorma-release to v0.2.23

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.4"
 gem "jekyll-calconnect-theme"
-gem "metanorma-release", github: "metanorma/metanorma-release", tag: "v0.2.22"
+gem "metanorma-release", github: "metanorma/metanorma-release", tag: "v0.2.23"
 gem "octokit", "~> 9.0"
 gem "relaton-calconnect", "~> 2.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/metanorma/metanorma-release.git
-  revision: 2cad6141751b1c6e135b939a574a740aa06b5391
-  tag: v0.2.22
+  revision: 5c3224b80269d7658b719b60a0bd9602b3879b25
+  tag: v0.2.23
   specs:
-    metanorma-release (0.2.22)
+    metanorma-release (0.2.23)
       relaton-bib (~> 2.1)
       thor (~> 1.0)
 
@@ -358,7 +358,7 @@ CHECKSUMS
   lutaml-model (0.8.11) sha256=deaa87d51e1d11ba85de4aaeded9fdd2a948c0d92fb379d0ca28898dca75ed03
   mechanize (2.14.0) sha256=33e76b7639d0181a46eaf1136b05f0e9043dfc5fc4b1a7b9fd8ae8bd437dd5e4
   mercenary (0.4.0) sha256=b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138
-  metanorma-release (0.2.22)
+  metanorma-release (0.2.23)
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
   mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   moxml (0.1.20) sha256=917811354a0752371089690c019fb3b0c9599085d6544a0752c85fa22ddd7dc6


### PR DESCRIPTION
Bump gem to v0.2.23 which fixes delta cache re-extraction when output files are missing from disk. This fixes empty doctypes and display categories in documents.json.