### PR TITLE
fix: use actual file paths in templates, add missing pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "jekyll", "~> 4.4"
 gem "jekyll-calconnect-theme"
-gem "metanorma-release", github: "metanorma/metanorma-release", tag: "v0.2.23"
+gem "metanorma-release", github: "metanorma/metanorma-release", tag: "v0.2.24"
 gem "octokit", "~> 9.0"
 gem "relaton-calconnect", "~> 2.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/metanorma/metanorma-release.git
-  revision: 5c3224b80269d7658b719b60a0bd9602b3879b25
-  tag: v0.2.23
+  revision: 608dc6d2d14efa4bd07f7f66137baeb586ecfb6c
+  tag: v0.2.24
   specs:
-    metanorma-release (0.2.23)
+    metanorma-release (0.2.24)
       relaton-bib (~> 2.1)
       thor (~> 1.0)
 
@@ -358,7 +358,7 @@ CHECKSUMS
   lutaml-model (0.8.11) sha256=deaa87d51e1d11ba85de4aaeded9fdd2a948c0d92fb379d0ca28898dca75ed03
   mechanize (2.14.0) sha256=33e76b7639d0181a46eaf1136b05f0e9043dfc5fc4b1a7b9fd8ae8bd437dd5e4
   mercenary (0.4.0) sha256=b25a1e4a59adca88665e08e24acf0af30da5b5d859f7d8f38fba52c28f405138
-  metanorma-release (0.2.23)
+  metanorma-release (0.2.24)
   mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
   mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   moxml (0.1.20) sha256=917811354a0752371089690c019fb3b0c9599085d6544a0752c85fa22ddd7dc6

--- a/_frontend/js/home.js
+++ b/_frontend/js/home.js
@@ -66,7 +66,7 @@
         box.innerHTML = '<div class="gs-empty">No documents match &ldquo;' + esc(q) + '&rdquo;</div>';
       } else {
         box.innerHTML = hits.map(function(d) {
-          var href = d.has_html ? '/cc/' + d.slug + '.html' : '/' + typeSlug(d.doctype) + '/';
+          var href = d.has_html ? '/cc/' + d.html_path : '/' + typeSlug(d.doctype) + '/';
           return '<a href="' + href + '" class="gsr">' +
             '<span class="gsr-id">' + esc(d.id) + '</span>' +
             '<span class="gsr-title">' + esc(trunc(d.title, 50)) + '</span>' +

--- a/_layouts/doc-type.html
+++ b/_layouts/doc-type.html
@@ -71,7 +71,7 @@ layout: base
     <div class="document stage-border-{{ doc.stage_css }}" data-stage="{{ doc.stage }}" data-id="{{ doc.id | downcase }}" data-date="{{ doc.date }}" data-title="{{ doc.title | downcase }}" data-search="{{ doc.id | downcase | escape }} {{ doc.title | downcase | escape }}">
       <div class="doc-header">
         {% if doc.has_html %}
-        <a href="/cc/{{ doc.slug }}.html" class="doc-identifier">{{ doc.id | escape }}</a>
+        <a href="/cc/{{ doc.html_path }}" class="doc-identifier">{{ doc.id | escape }}</a>
         {% else %}
         <span class="doc-identifier">{{ doc.id | escape }}</span>
         {% endif %}
@@ -91,7 +91,7 @@ layout: base
       </div>
       <div class="doc-body">
         {% if doc.has_html %}
-        <a href="/cc/{{ doc.slug }}.html" class="doc-title">{{ doc.title | escape }}</a>
+        <a href="/cc/{{ doc.html_path }}" class="doc-title">{{ doc.title | escape }}</a>
         {% else %}
         <div class="doc-title">{{ doc.title | escape }}</div>
         {% endif %}
@@ -109,17 +109,17 @@ layout: base
       <div class="doc-actions">
         <div class="doc-downloads">
           {% if doc.has_html %}
-          <a href="/cc/{{ doc.slug }}.html" class="dl-btn dl-html"><svg class="dl-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg> HTML</a>
+          <a href="/cc/{{ doc.html_path }}" class="dl-btn dl-html"><svg class="dl-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg> HTML</a>
           {% endif %}
           {% if doc.has_pdf %}
-          <a href="/cc/{{ doc.slug }}.pdf" class="dl-btn dl-pdf"><svg class="dl-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/></svg> PDF</a>
+          <a href="/cc/{{ doc.pdf_path }}" class="dl-btn dl-pdf"><svg class="dl-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 21h10a2 2 0 002-2V9.414a1 1 0 00-.293-.707l-5.414-5.414A1 1 0 0012.586 3H7a2 2 0 00-2 2v14a2 2 0 002 2z"/></svg> PDF</a>
           {% endif %}
           {% if doc.has_xml %}
-          <a href="/cc/{{ doc.slug }}.xml" class="dl-btn dl-xml"><svg class="dl-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg> XML</a>
+          <a href="/cc/{{ doc.xml_path }}" class="dl-btn dl-xml"><svg class="dl-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"/></svg> XML</a>
           {% endif %}
         </div>
         {% if doc.has_rxl %}
-        <a href="/cc/{{ doc.slug }}.rxl" class="doc-relaton-link" title="Relaton bibliographic data"><svg class="dl-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/></svg> Relaton</a>
+        <a href="/cc/{{ doc.rxl_path }}" class="doc-relaton-link" title="Relaton bibliographic data"><svg class="dl-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4"/></svg> Relaton</a>
         {% endif %}
       </div>
     </div>

--- a/_pages/amendments.html
+++ b/_pages/amendments.html
@@ -1,0 +1,7 @@
+---
+layout: doc-type
+title: Amendments & Technical Corrigenda
+display_category_slug: amendments
+subtitle_hint: amendments and corrigenda
+description: Amendments and technical corrigenda to published CalConnect Standards.
+---

--- a/_pages/index.html
+++ b/_pages/index.html
@@ -115,7 +115,7 @@ permalink: /
   <h2 class="home-section-title">Recently Published</h2>
   <div class="home-recent-grid">
     {% for doc in recent limit: 6 %}
-    <a href="{% if doc.has_html %}/cc/{{ doc.slug }}.html{% else %}/{% if doc.display_category_slug %}{{ doc.display_category_slug }}{% else %}{{ doc.doctype }}{% endif %}/{% endif %}" class="recent-card">
+    <a href="{% if doc.has_html %}/cc/{{ doc.html_path }}{% else %}/{% if doc.display_category_slug %}{{ doc.display_category_slug }}{% else %}{{ doc.doctype }}{% endif %}/{% endif %}" class="recent-card">
       <div class="recent-card-top">
         <span class="recent-card-id">{{ doc.id | escape }}</span>
         <span class="doc-type-badge {{ doc.doctype_class }}">{{ doc.doctype }}</span>

--- a/_pages/public-review.html
+++ b/_pages/public-review.html
@@ -1,0 +1,8 @@
+---
+layout: doc-type
+title: Public Review
+stage_filter:
+  - public-review
+subtitle_hint: documents in public review
+description: CalConnect documents currently in public review.
+---


### PR DESCRIPTION
Fixes broken links for documents with stage-suffixed filenames (e.g. cc-wd-51020-2019-wd.html vs cc-wd-51020-2019.html).

- Templates use doc.html_path/pdf_path/xml_path/rxl_path from documents.json
- Added /amendments/ and /public-review/ pages (were linked in footer but missing)
- Bumped metanorma-release to v0.2.24
- Fixed JS global search to use doc.html_path

Lychee audit: 134 OK, 0 broken internal links